### PR TITLE
Optimize TextFormatter.kt

### DIFF
--- a/src/main/java/com/sup/dev/java/libs/text_format/TextFormatter.kt
+++ b/src/main/java/com/sup/dev/java/libs/text_format/TextFormatter.kt
@@ -1,7 +1,6 @@
 package com.sup.dev.java.libs.text_format
 
 import com.sup.dev.java.libs.debug.err
-import com.sup.dev.java.libs.debug.info
 import com.sup.dev.java.tools.ToolsText
 import java.util.*
 
@@ -28,9 +27,7 @@ class TextFormatter(
     private var skipToNextNoFormat = false
 
     fun parseHtml(): String {
-        val start = System.currentTimeMillis()
         if (result == null) parseText()
-        info("TextFormatter: parsed in ${System.currentTimeMillis() - start}ms: (${text.length}) ${text.subSequence(0, 100.coerceAtMost(text.length))}")
         return result.toString()
     }
 


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/20511387/152168794-cef6cf51-97e9-413b-96b7-886b11c87ee2.png)
After:
![after](https://user-images.githubusercontent.com/20511387/152168672-6509c6fd-26fc-4ce1-a1e1-9d5bd2ed8168.png)

It was laggy because every character reallocated the whole `result` string in memory, and it created huge freezes for long strings.